### PR TITLE
Implement styling of excel exports

### DIFF
--- a/src/simultaneousness_analysis/excel.py
+++ b/src/simultaneousness_analysis/excel.py
@@ -67,7 +67,7 @@ class ExcelTableOptions:
     coordinate_columns: frozenset[str] | None = None
 
 
-def _sanitize_table_name(name: str) -> str:
+def _normalize_table_name(name: str) -> str:
     """Normalize a raw table name so it is valid in Excel.
 
     This replaces invalid characters with underscores and ensures the name
@@ -141,32 +141,50 @@ def _style_data_cells(
         dataframe: Dataframe used to define the table range.
         options: Styling options that include column-specific formats.
     """
+    # Iterate rows
     for row in worksheet.iter_rows(
         min_row=2,
         max_row=worksheet.max_row,
         max_col=dataframe.shape[1],
     ):
+        # Iterate cells in row
         for column_index, cell in enumerate(row, start=1):
             cell.alignment = DEFAULT_CELL_ALIGNMENT
-            if isinstance(cell.value, (datetime, date)) and not isinstance(
-                cell.value,
-                bool,
-            ):
+            # bool is not a number, but should not be formatted as text, so check for it first
+            if isinstance(cell.value, bool):
+                continue
+            # check for date/datetime
+            if isinstance(cell.value, (datetime, date)):
                 cell.number_format = DEFAULT_DATE_FORMAT
-            elif isinstance(cell.value, Number) and not isinstance(cell.value, bool):
-                column_name = dataframe.columns[column_index - 1]
-                if (
-                    options.integer_columns is not None
-                    and column_name in options.integer_columns
-                ):
-                    cell.number_format = DEFAULT_INTEGER_FORMAT
-                elif (
-                    options.coordinate_columns is not None
-                    and column_name in options.coordinate_columns
-                ):
-                    cell.number_format = DEFAULT_COORDINATE_FORMAT
-                else:
-                    cell.number_format = DEFAULT_NUMERIC_FORMAT
+                continue
+            # Skip non-numeric cells
+            if not isinstance(cell.value, Number):
+                continue
+            column_name = dataframe.columns[column_index - 1]
+            cell.number_format = _number_format_for_column(column_name, options)
+
+
+def _number_format_for_column(
+    column_name: str,
+    options: ExcelTableOptions,
+) -> str:
+    """Return the numeric format for a column based on styling options.
+
+    Args:
+        column_name: Name of the dataframe column.
+        options: Options containing integer and coordinate column sets.
+
+    Returns:
+        A number format string for Excel cell formatting.
+    """
+    if options.integer_columns is not None and column_name in options.integer_columns:
+        return DEFAULT_INTEGER_FORMAT
+    if (
+        options.coordinate_columns is not None
+        and column_name in options.coordinate_columns
+    ):
+        return DEFAULT_COORDINATE_FORMAT
+    return DEFAULT_NUMERIC_FORMAT
 
 
 def _apply_column_widths(
@@ -204,7 +222,7 @@ def create_excel_table(
         options = ExcelTableOptions()
 
     table_name = options.table_name or f"Table_{worksheet.title}"
-    table_name = _sanitize_table_name(table_name)
+    table_name = _normalize_table_name(table_name)
     end_column = get_column_letter(dataframe.shape[1])
     end_row = dataframe.shape[0] + 1
     table_ref = f"A1:{end_column}{end_row}"

--- a/src/simultaneousness_analysis/excel.py
+++ b/src/simultaneousness_analysis/excel.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from numbers import Number
+import re
+from typing import TYPE_CHECKING
+
+from openpyxl.styles import Alignment, Font, PatternFill
+from openpyxl.utils import get_column_letter
+from openpyxl.worksheet.table import Table, TableStyleInfo
+
+if TYPE_CHECKING:
+    from openpyxl.worksheet.worksheet import Worksheet
+    import pandas as pd
+
+# Default Excel table style name used for all exported tables.
+DEFAULT_EXCEL_TABLE_STYLE = "TableStyleMedium9"
+
+# Default numeric format for non-coordinate numeric values.
+DEFAULT_NUMERIC_FORMAT = "0.000"
+
+# Default integer format for unique identifiers.
+DEFAULT_INTEGER_FORMAT = "0"
+
+# Higher precision format for latitude and longitude values.
+DEFAULT_COORDINATE_FORMAT = "0.000000"
+
+# Date-only display format for datetime values in exported sheets.
+DEFAULT_DATE_FORMAT = "yyyy-mm-dd"
+
+# Header cell fill color used for table headers.
+DEFAULT_HEADER_FILL = "FFD9E1F2"
+
+# Header font should be bold for readability.
+DEFAULT_HEADER_FONT_BOLD = True
+
+# Header alignment used for table header cells.
+DEFAULT_HEADER_ALIGNMENT = Alignment(horizontal="center", vertical="center")
+
+# Default alignment for data cells, including wrap text for long values.
+DEFAULT_CELL_ALIGNMENT = Alignment(wrap_text=True, vertical="top")
+
+# Minimum and maximum column widths used when auto-sizing.
+DEFAULT_COLUMN_WIDTH_MIN = 12.0
+DEFAULT_COLUMN_WIDTH_MAX = 40.0
+
+
+@dataclass(frozen=True)
+class ExcelTableOptions:
+    """Options for creating a styled Excel table.
+
+    Attributes:
+        table_name: Optional table display name.
+        table_style: Excel table style name.
+        min_column_width: Minimum width in Excel units.
+        max_column_width: Maximum width in Excel units.
+        integer_columns: Column names whose numeric values should use integer formatting.
+        coordinate_columns: Column names whose numeric values should use coordinate precision.
+    """
+
+    table_name: str | None = None
+    table_style: str = DEFAULT_EXCEL_TABLE_STYLE
+    min_column_width: float = DEFAULT_COLUMN_WIDTH_MIN
+    max_column_width: float = DEFAULT_COLUMN_WIDTH_MAX
+    integer_columns: frozenset[str] | None = None
+    coordinate_columns: frozenset[str] | None = None
+
+
+def _sanitize_table_name(name: str) -> str:
+    """Normalize a raw table name so it is valid in Excel.
+
+    This replaces invalid characters with underscores and ensures the name
+    does not begin with a digit, which is required by Excel table naming rules.
+
+    Args:
+        name: Raw worksheet title.
+
+    Returns:
+        A valid Excel table name.
+    """
+    sanitized = re.sub(r"[^A-Za-z0-9_]", "_", name)
+    if not sanitized:
+        sanitized = "Table1"
+    if sanitized[0].isdigit():
+        sanitized = f"T_{sanitized}"
+    return sanitized
+
+
+def _get_column_widths(
+    dataframe: pd.DataFrame,
+    min_width: float,
+    max_width: float,
+) -> dict[int, float]:
+    """Compute column widths from dataframe contents and clamp them to bounds.
+
+    Each width is based on the longest text in the column, then bounded by
+    the provided minimum and maximum widths.
+
+    Args:
+        dataframe: Dataframe to measure.
+        min_width: Minimum width in Excel units.
+        max_width: Maximum width in Excel units.
+
+    Returns:
+        Mapping of 1-based column indexes to computed widths.
+    """
+    widths: dict[int, float] = {}
+    for index, column in enumerate(dataframe.columns, start=1):
+        header_width = len(str(column))
+        max_text_width = header_width
+        for value in dataframe[column].astype(str):
+            max_text_width = max(max_text_width, len(value))
+
+        width = max(min_width, min(max_text_width + 2.0, max_width))
+        widths[index] = width
+    return widths
+
+
+def _style_header_row(worksheet: Worksheet) -> None:
+    """Apply header styling to the first row (header) of the worksheet.
+
+    Args:
+        worksheet: Worksheet instance to style.
+    """
+    for cell in worksheet[1]:
+        cell.font = Font(bold=DEFAULT_HEADER_FONT_BOLD)
+        cell.fill = PatternFill(fill_type="solid", fgColor=DEFAULT_HEADER_FILL)
+        cell.alignment = DEFAULT_HEADER_ALIGNMENT
+
+
+def _style_data_cells(
+    worksheet: Worksheet,
+    dataframe: pd.DataFrame,
+    options: ExcelTableOptions,
+) -> None:
+    """Apply cell formatting to numeric, date, and text cells.
+
+    Args:
+        worksheet: Worksheet instance to format.
+        dataframe: Dataframe used to define the table range.
+        options: Styling options that include column-specific formats.
+    """
+    for row in worksheet.iter_rows(
+        min_row=2,
+        max_row=worksheet.max_row,
+        max_col=dataframe.shape[1],
+    ):
+        for column_index, cell in enumerate(row, start=1):
+            cell.alignment = DEFAULT_CELL_ALIGNMENT
+            if isinstance(cell.value, (datetime, date)) and not isinstance(
+                cell.value,
+                bool,
+            ):
+                cell.number_format = DEFAULT_DATE_FORMAT
+            elif isinstance(cell.value, Number) and not isinstance(cell.value, bool):
+                column_name = dataframe.columns[column_index - 1]
+                if (
+                    options.integer_columns is not None
+                    and column_name in options.integer_columns
+                ):
+                    cell.number_format = DEFAULT_INTEGER_FORMAT
+                elif (
+                    options.coordinate_columns is not None
+                    and column_name in options.coordinate_columns
+                ):
+                    cell.number_format = DEFAULT_COORDINATE_FORMAT
+                else:
+                    cell.number_format = DEFAULT_NUMERIC_FORMAT
+
+
+def _apply_column_widths(
+    worksheet: Worksheet,
+    dataframe: pd.DataFrame,
+    min_width: float,
+    max_width: float,
+) -> None:
+    """Set column widths on the worksheet based on data content.
+
+    Args:
+        worksheet: Worksheet instance to adjust.
+        dataframe: Dataframe used to determine widths.
+        min_width: Minimum width in Excel units.
+        max_width: Maximum width in Excel units.
+    """
+    widths = _get_column_widths(dataframe, min_width, max_width)
+    for index, width in widths.items():
+        worksheet.column_dimensions[get_column_letter(index)].width = width
+
+
+def create_excel_table(
+    worksheet: Worksheet,
+    dataframe: pd.DataFrame,
+    options: ExcelTableOptions | None = None,
+) -> None:
+    """Create and style an Excel table from a dataframe.
+
+    Args:
+        worksheet: Worksheet instance to populate.
+        dataframe: Dataframe to write as a table.
+        options: Optional table styling options.
+    """
+    if options is None:
+        options = ExcelTableOptions()
+
+    table_name = options.table_name or f"Table_{worksheet.title}"
+    table_name = _sanitize_table_name(table_name)
+    end_column = get_column_letter(dataframe.shape[1])
+    end_row = dataframe.shape[0] + 1
+    table_ref = f"A1:{end_column}{end_row}"
+
+    table = Table(displayName=table_name, ref=table_ref)
+    table.tableStyleInfo = TableStyleInfo(
+        name=options.table_style,
+        showFirstColumn=False,
+        showLastColumn=False,
+        showRowStripes=True,
+        showColumnStripes=False,
+    )
+
+    worksheet.add_table(table)
+    _style_header_row(worksheet)
+    _style_data_cells(worksheet, dataframe, options)
+    _apply_column_widths(
+        worksheet,
+        dataframe,
+        options.min_column_width,
+        options.max_column_width,
+    )

--- a/src/simultaneousness_analysis/meta/table.py
+++ b/src/simultaneousness_analysis/meta/table.py
@@ -1,13 +1,13 @@
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from .search import MetaSearch
 
 from matplotlib import path
 import pandas as pd
 
+from ..excel import ExcelTableOptions, create_excel_table
 from .config import (
     META_JSON_COLUMN_MAPPING,
     META_JSON_FILES,
@@ -208,5 +208,16 @@ class MetaTable:
         if suffix == "json":
             self.table.to_json(path, orient="records", indent=4)
         if suffix == "xlsx":
-            with pd.ExcelWriter(path) as writer:
-                self.table.to_excel(writer, sheet_name="Meta Table")
+            with pd.ExcelWriter(path, engine="openpyxl") as writer:
+                dataframe_export = self.table.reset_index()
+                dataframe_export.to_excel(writer, sheet_name="Meta Table", index=False)
+                worksheet = writer.sheets["Meta Table"]
+                options = ExcelTableOptions(
+                    integer_columns={"stations_id"},
+                    coordinate_columns={"latitude", "longitude"},
+                )
+                create_excel_table(
+                    worksheet=worksheet,
+                    dataframe=dataframe_export,
+                    options=options,
+                )

--- a/tests/meta/test_excel_export.py
+++ b/tests/meta/test_excel_export.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+from openpyxl import load_workbook
+import pandas as pd
+
+from simultaneousness_analysis.meta.table import MetaTable
+
+
+def test_meta_table_xlsx_export_uses_table_and_styles(tmp_path: Path) -> None:
+    meta_table = MetaTable.__new__(MetaTable)
+    meta_table.data_path = tmp_path
+    meta_table.table = pd.DataFrame(
+        {
+            "stations_id": [4466, 2907],
+            "station_name": ["Test Station", "Another Station"],
+            "measurement": [1.23456, 7.0],
+            "latitude": [54.5275, 54.7903],
+            "longitude": [9.5487, 8.9514],
+            "from_date": ["2000-01-01", "2001-05-13"],
+            "to_date": ["2000-12-31", "2001-12-31"],
+            "notes": [
+                "Short text",
+                "A longer piece of text that should wrap automatically.",
+            ],
+        },
+    )
+    meta_table.table["from_date"] = pd.to_datetime(meta_table.table["from_date"])
+    meta_table.table["to_date"] = pd.to_datetime(meta_table.table["to_date"])
+    meta_table.table.index = pd.Index(["path-a", "path-b"], name="path")
+
+    output_path = tmp_path / "meta_table.xlsx"
+    meta_table.export(suffix="xlsx", path=output_path)
+
+    workbook = load_workbook(output_path)
+    worksheet = workbook["Meta Table"]
+
+    assert len(worksheet._tables) == 1
+    table = next(iter(worksheet._tables.values()))
+    assert table.ref == "A1:I3"
+    assert table.displayName.startswith("Table")
+
+    header_row = next(worksheet.iter_rows(min_row=1, max_row=1, max_col=9))
+    for cell in header_row:
+        assert cell.font.bold is True
+        assert cell.fill.fill_type == "solid"
+
+    assert worksheet["B2"].number_format == "0"
+    assert worksheet["B3"].number_format == "0"
+    assert worksheet["D2"].number_format == "0.000"
+    assert worksheet["D3"].number_format == "0.000"
+    assert worksheet["E2"].number_format == "0.000000"
+    assert worksheet["E3"].number_format == "0.000000"
+    assert worksheet["F2"].number_format == "0.000000"
+    assert worksheet["F3"].number_format == "0.000000"
+    assert worksheet["G2"].number_format == "yyyy-mm-dd"
+    assert worksheet["G3"].number_format == "yyyy-mm-dd"
+    assert worksheet["H2"].number_format == "yyyy-mm-dd"
+    assert worksheet["H3"].number_format == "yyyy-mm-dd"
+    assert worksheet["I2"].alignment.wrap_text is True
+    assert worksheet["I3"].alignment.wrap_text is True
+
+    column_widths = [
+        worksheet.column_dimensions[col].width
+        for col in ["A", "B", "C", "D", "E", "F", "G", "H", "I"]
+    ]
+    assert all(width is not None for width in column_widths)
+    assert all(12.0 <= width <= 40.0 for width in column_widths)

--- a/tests/meta/test_excel_export.py
+++ b/tests/meta/test_excel_export.py
@@ -6,7 +6,8 @@ import pandas as pd
 from simultaneousness_analysis.meta.table import MetaTable
 
 
-def test_meta_table_xlsx_export_uses_table_and_styles(tmp_path: Path) -> None:
+def _create_meta_table(tmp_path: Path) -> tuple[MetaTable, Path]:
+    """Build and export a sample meta table for worksheet validation."""
     meta_table = MetaTable.__new__(MetaTable)
     meta_table.data_path = tmp_path
     meta_table.table = pd.DataFrame(
@@ -30,38 +31,97 @@ def test_meta_table_xlsx_export_uses_table_and_styles(tmp_path: Path) -> None:
 
     output_path = tmp_path / "meta_table.xlsx"
     meta_table.export(suffix="xlsx", path=output_path)
+    return meta_table, output_path
 
+
+def _load_meta_table_worksheet(output_path: Path):
+    """Load the exported worksheet for assertions."""
     workbook = load_workbook(output_path)
-    worksheet = workbook["Meta Table"]
+    return workbook["Meta Table"]
+
+
+def test_meta_table_xlsx_export_creates_excel_table(tmp_path: Path) -> None:
+    """Verify an Excel table is created and named correctly."""
+    _, output_path = _create_meta_table(tmp_path)
+    worksheet = _load_meta_table_worksheet(output_path)
 
     assert len(worksheet._tables) == 1
     table = next(iter(worksheet._tables.values()))
     assert table.ref == "A1:I3"
     assert table.displayName.startswith("Table")
 
+
+def test_meta_table_xlsx_export_applies_header_styles(tmp_path: Path) -> None:
+    """Verify header formatting is applied to the exported sheet."""
+    _, output_path = _create_meta_table(tmp_path)
+    worksheet = _load_meta_table_worksheet(output_path)
+
     header_row = next(worksheet.iter_rows(min_row=1, max_row=1, max_col=9))
     for cell in header_row:
         assert cell.font.bold is True
         assert cell.fill.fill_type == "solid"
 
+
+def test_meta_table_xlsx_export_formats_integer_columns(tmp_path: Path) -> None:
+    """Verify integer columns use integer formatting."""
+    _, output_path = _create_meta_table(tmp_path)
+    worksheet = _load_meta_table_worksheet(output_path)
+
     assert worksheet["B2"].number_format == "0"
     assert worksheet["B3"].number_format == "0"
+
+
+def test_meta_table_xlsx_export_formats_default_numeric_columns(tmp_path: Path) -> None:
+    """Verify default numeric columns use standard decimal formatting."""
+    _, output_path = _create_meta_table(tmp_path)
+    worksheet = _load_meta_table_worksheet(output_path)
+
     assert worksheet["D2"].number_format == "0.000"
     assert worksheet["D3"].number_format == "0.000"
+
+
+def test_meta_table_xlsx_export_formats_coordinate_columns(tmp_path: Path) -> None:
+    """Verify coordinate columns use higher precision formatting."""
+    _, output_path = _create_meta_table(tmp_path)
+    worksheet = _load_meta_table_worksheet(output_path)
+
     assert worksheet["E2"].number_format == "0.000000"
     assert worksheet["E3"].number_format == "0.000000"
     assert worksheet["F2"].number_format == "0.000000"
     assert worksheet["F3"].number_format == "0.000000"
+
+
+def test_meta_table_xlsx_export_formats_date_columns(tmp_path: Path) -> None:
+    """Verify date columns are formatted using the date format."""
+    _, output_path = _create_meta_table(tmp_path)
+    worksheet = _load_meta_table_worksheet(output_path)
+
     assert worksheet["G2"].number_format == "yyyy-mm-dd"
     assert worksheet["G3"].number_format == "yyyy-mm-dd"
     assert worksheet["H2"].number_format == "yyyy-mm-dd"
     assert worksheet["H3"].number_format == "yyyy-mm-dd"
+
+
+def test_meta_table_xlsx_export_wraps_text_in_notes(tmp_path: Path) -> None:
+    """Verify text wrapping is enabled for the notes column."""
+    _, output_path = _create_meta_table(tmp_path)
+    worksheet = _load_meta_table_worksheet(output_path)
+
     assert worksheet["I2"].alignment.wrap_text is True
     assert worksheet["I3"].alignment.wrap_text is True
+
+
+def test_meta_table_xlsx_export_sets_column_widths_within_bounds(
+    tmp_path: Path,
+) -> None:
+    """Verify all column widths stay inside the configured bounds."""
+    _, output_path = _create_meta_table(tmp_path)
+    worksheet = _load_meta_table_worksheet(output_path)
 
     column_widths = [
         worksheet.column_dimensions[col].width
         for col in ["A", "B", "C", "D", "E", "F", "G", "H", "I"]
     ]
+
     assert all(width is not None for width in column_widths)
     assert all(12.0 <= width <= 40.0 for width in column_widths)


### PR DESCRIPTION
# Pull Request: Define Common Styling for All Excel Result Files

## Summary

This change introduces a shared Excel styling utility and applies it to meta table exports.

## Files Changed

- `src/simultaneousness_analysis/excel.py`
  - Added reusable Excel table styling helpers.
  - Defined default table styles, header formatting, numeric/date formatting, and autosized column widths.
  - Added Excel table name sanitization and support for column-specific integer/coordinate formatting.
- `src/simultaneousness_analysis/meta/table.py`
  - Replaced direct `.xlsx` export with reusable `create_excel_table(...)` styling.
  - Uses `openpyxl` and `pandas.ExcelWriter` for consistent export behavior.
  - Applied integer formatting for `stations_id` and coordinate formatting for `latitude` and `longitude`.
- `tests/meta/test_excel_export.py`
  - Added regression tests for Excel export styling, table creation, and formatting.

## Benefits

- Establishes a common, extensible Excel styling foundation for all exported result files.
- Improves readability of exported Excel reports.
- Ensures consistent formatting across worksheet exports.
- Makes future exports easier to style and maintain.

## Tests

- `pytest tests/meta/test_excel_export.py`

## Notes

- The new utility is intentionally generic so it can be reused for other Excel exports in the project.
- The `MetaTable` export now writes a styled table rather than a plain worksheet.